### PR TITLE
Add ContextMenuCommandBuilder and related user/message command builders

### DIFF
--- a/src/commands/ContextMenuCommandBuilder.ts
+++ b/src/commands/ContextMenuCommandBuilder.ts
@@ -1,0 +1,182 @@
+import {
+	ApplicationCommandType,
+	type LocalizationMap,
+	type Permissions,
+	type RESTPostAPIContextMenuApplicationCommandsJSONBody,
+} from "discord-api-types/v10";
+
+import { CommandContext, IntegrationType } from "./CommandBuilder.js";
+
+/**
+ * Base data structure for context menu commands.
+ */
+type ContextMenuCommandData = Partial<
+	Omit<
+		RESTPostAPIContextMenuApplicationCommandsJSONBody,
+		"contexts" | "integration_types" | "type"
+	>
+> & {
+	type: ApplicationCommandType.User | ApplicationCommandType.Message;
+	contexts?: CommandContext[] | null;
+	integration_types?: IntegrationType[];
+};
+
+/**
+ * Base builder for context menu commands (User and Message commands).
+ */
+abstract class BaseContextMenuCommandBuilder<
+	T extends ApplicationCommandType.User | ApplicationCommandType.Message,
+> {
+	protected readonly data: ContextMenuCommandData;
+
+	constructor(type: T) {
+		this.data = {
+			type,
+		};
+	}
+
+	/**
+	 * Sets the command name.
+	 * Context menu command names can be up to 32 characters and are displayed in the UI.
+	 */
+	setName(name: string): this {
+		if (!name || name.length === 0) {
+			throw new Error("Context menu command name cannot be empty");
+		}
+		if (name.length > 32) {
+			throw new RangeError(
+				"Context menu command name cannot exceed 32 characters",
+			);
+		}
+		this.data.name = name;
+		return this;
+	}
+
+	/**
+	 * Sets the localized names for the command.
+	 */
+	setNameLocalizations(nameLocalizations: LocalizationMap | null): this {
+		this.data.name_localizations = nameLocalizations ?? undefined;
+		return this;
+	}
+
+	/**
+	 * Sets the default member permissions required to use this command.
+	 */
+	setDefaultMemberPermissions(permissions: Permissions | null): this {
+		this.data.default_member_permissions =
+			permissions === null ? null : String(permissions);
+		return this;
+	}
+
+	/**
+	 * Sets whether the command is available in direct messages.
+	 */
+	setDMPermission(dmPermission: boolean): this {
+		this.data.dm_permission = dmPermission;
+		return this;
+	}
+
+	/**
+	 * Marks the command as not safe for work.
+	 */
+	setNSFW(nsfw: boolean): this {
+		this.data.nsfw = nsfw;
+		return this;
+	}
+
+	/**
+	 * Limits the contexts in which the command can appear.
+	 */
+	setContexts(contexts: CommandContext[] | null): this {
+		this.data.contexts = contexts ? [...contexts] : null;
+		return this;
+	}
+
+	/**
+	 * Specifies the integration types supported by the command.
+	 */
+	setIntegrationTypes(integrationTypes: IntegrationType[]): this {
+		this.data.integration_types = [...integrationTypes];
+		return this;
+	}
+
+	/**
+	 * Produces the final REST payload for the configured command.
+	 */
+	toJSON(): RESTPostAPIContextMenuApplicationCommandsJSONBody {
+		const { name, type } = this.data;
+		if (!name) {
+			throw new Error("Context menu command name has not been set");
+		}
+
+		const contexts = this.data.contexts;
+		const integrationTypes = this.data.integration_types;
+
+		return {
+			...this.data,
+			name,
+			type,
+			contexts:
+				contexts === null
+					? null
+					: Array.isArray(contexts)
+					? [...contexts]
+					: undefined,
+			integration_types: Array.isArray(integrationTypes)
+				? [...integrationTypes]
+				: integrationTypes ?? undefined,
+		} as RESTPostAPIContextMenuApplicationCommandsJSONBody;
+	}
+
+	/**
+	 * Allows the builder to be coerced into its JSON payload automatically.
+	 */
+	valueOf(): RESTPostAPIContextMenuApplicationCommandsJSONBody {
+		return this.toJSON();
+	}
+
+	/**
+	 * Formats the command as JSON when inspected in Node.js runtimes.
+	 */
+	[Symbol.for(
+		"nodejs.util.inspect.custom",
+	)](): RESTPostAPIContextMenuApplicationCommandsJSONBody {
+		return this.toJSON();
+	}
+}
+
+/**
+ * Builder for User context menu commands.
+ * These commands appear when right-clicking on a user.
+ *
+ * @example
+ * ```typescript
+ * const userCommand = new UserCommandBuilder()
+ *   .setName('User Info')
+ *   .toJSON();
+ * ```
+ */
+export class UserCommandBuilder extends BaseContextMenuCommandBuilder<ApplicationCommandType.User> {
+	constructor() {
+		super(ApplicationCommandType.User);
+	}
+}
+
+/**
+ * Builder for Message context menu commands.
+ * These commands appear when right-clicking on a message.
+ *
+ * @example
+ * ```typescript
+ * const messageCommand = new MessageCommandBuilder()
+ *   .setName('Report Message')
+ *   .toJSON();
+ * ```
+ */
+export class MessageCommandBuilder extends BaseContextMenuCommandBuilder<ApplicationCommandType.Message> {
+	constructor() {
+		super(ApplicationCommandType.Message);
+	}
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,10 @@ export {
 	CommandContext,
 	IntegrationType,
 } from "./commands/CommandBuilder.js";
+export {
+	UserCommandBuilder,
+	MessageCommandBuilder,
+} from "./commands/ContextMenuCommandBuilder.js";
 export type {
 	AttachmentOptionBuilder,
 	ChannelOptionBuilder,
@@ -44,7 +48,11 @@ export type {
 	MiniInteractionModalHandler,
 	MiniInteractionHandler,
 } from "./clients/MiniInteraction.js";
-export type { MessageComponentInteraction } from "./utils/MessageComponentInteraction.js";
+export type {
+	MessageComponentInteraction,
+	ResolvedUserOption as ComponentResolvedUserOption,
+	ResolvedMentionableOption as ComponentResolvedMentionableOption,
+} from "./utils/MessageComponentInteraction.js";
 export type { ModalSubmitInteraction } from "./utils/ModalSubmitInteraction.js";
 export { RoleConnectionMetadataTypes } from "./types/RoleConnectionMetadataTypes.js";
 export { ChannelType } from "./types/ChannelType.js";

--- a/src/utils/CommandInteractionOptions.ts
+++ b/src/utils/CommandInteractionOptions.ts
@@ -5,7 +5,9 @@ import {
 	type APIInteractionResponse,
 	type APIApplicationCommandInteractionDataAttachmentOption,
 	type APIApplicationCommandInteractionDataBasicOption,
+	type APIApplicationCommandInteractionDataBooleanOption,
 	type APIApplicationCommandInteractionDataChannelOption,
+	type APIApplicationCommandInteractionDataIntegerOption,
 	type APIApplicationCommandInteractionDataMentionableOption,
 	type APIApplicationCommandInteractionDataNumberOption,
 	type APIApplicationCommandInteractionDataOption,
@@ -230,15 +232,43 @@ export class CommandInteractionOptionResolver {
 	}
 
 	/**
-	 * Looks up a numeric option by name.
+	 * Looks up an integer option by name.
 	 *
 	 * @param name - The option name to resolve.
 	 * @param required - Whether to throw when the option is missing.
+	 */
+	getInteger(name: string, required = false): number | null {
+		const option = this.extractOption<
+			APIApplicationCommandInteractionDataIntegerOption<InteractionType.ApplicationCommand>
+		>(name, ApplicationCommandOptionType.Integer, required);
+		return option ? option.value : null;
+	}
+
+	/**
+	 * Looks up a numeric option by name.
+	 *
+	 * @param name - The option name to resolve.
 	 */
 	getNumber(name: string, required = false): number | null {
 		const option = this.extractOption<
 			APIApplicationCommandInteractionDataNumberOption<InteractionType.ApplicationCommand>
 		>(name, ApplicationCommandOptionType.Number, required);
+		return option ? option.value : null;
+	}
+
+	/**
+	 * Looks up a boolean option by name.
+	 *
+	 * @param name - The option name to resolve.
+	 * @param required - Whether to throw when the option is missing.
+	 */
+	getBoolean(name: string, required = false): boolean | null {
+		const option =
+			this.extractOption<APIApplicationCommandInteractionDataBooleanOption>(
+				name,
+				ApplicationCommandOptionType.Boolean,
+				required,
+			);
 		return option ? option.value : null;
 	}
 


### PR DESCRIPTION
Introduce a new `ContextMenuCommandBuilder` along with builders for user and message context menu commands. Enhance interaction handling by adding methods for resolving boolean, integer, and mentionable options. Include helper methods for select menu interactions to improve usability.