### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-to-github-packages.yml
+++ b/.github/workflows/publish-to-github-packages.yml
@@ -1,4 +1,7 @@
 name: Publish to GitHub Packages
+permissions:
+  contents: read
+  packages: write
 
 on:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/minesa-org/mini-interaction/security/code-scanning/1](https://github.com/minesa-org/mini-interaction/security/code-scanning/1)

To fix this problem, the `permissions` key should be added to the workflow. The `permissions` block can be defined either at the top level of the workflow (to apply to all jobs) or at the job level (to apply only to specific jobs). Since there is a single job in this workflow, and all steps need only publish to GitHub Packages, we should set the permissions to the least required for this job. According to GitHub’s documentation, publishing packages requires `packages: write` and reading repository contents usually requires `contents: read`. Therefore, the minimal permissions block should be:

```yaml
permissions:
  contents: read
  packages: write
```

This block should be added at the workflow (top) level, just after the workflow name, before the `on:` section, to clearly express the configuration for the entire workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
