### PR TITLE
Add primary entry point command support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,9 @@ export {
 	IntegrationType,
 } from "./commands/CommandBuilder.js";
 export {
-	UserCommandBuilder,
-	MessageCommandBuilder,
+        UserCommandBuilder,
+        MessageCommandBuilder,
+        AppCommandBuilder,
 } from "./commands/ContextMenuCommandBuilder.js";
 export type {
 	AttachmentOptionBuilder,
@@ -28,11 +29,12 @@ export {
 export type {
 	CommandInteraction,
 	MentionableOption,
-	ResolvedUserOption,
+        ResolvedUserOption,
 } from "./utils/CommandInteractionOptions.js";
 export type {
-	UserContextMenuInteraction,
-	MessageContextMenuInteraction,
+        UserContextMenuInteraction,
+        MessageContextMenuInteraction,
+        AppCommandInteraction,
 } from "./utils/ContextMenuInteraction.js";
 export type {
         MiniInteractionFetchHandler,
@@ -50,11 +52,12 @@ export type {
         DiscordOAuthVerificationPageOptions,
 } from "./clients/MiniInteraction.js";
 export type {
-	MiniInteractionCommand,
-	SlashCommandHandler,
-	UserCommandHandler,
-	MessageCommandHandler,
-	CommandHandler,
+        MiniInteractionCommand,
+        SlashCommandHandler,
+        UserCommandHandler,
+        MessageCommandHandler,
+        AppCommandHandler,
+        CommandHandler,
 } from "./types/Commands.js";
 export type {
 	MiniInteractionComponent,

--- a/src/types/Commands.ts
+++ b/src/types/Commands.ts
@@ -1,13 +1,15 @@
 import type {
-	APIInteractionResponse,
-	RESTPostAPIChatInputApplicationCommandsJSONBody,
-	RESTPostAPIContextMenuApplicationCommandsJSONBody,
+        APIInteractionResponse,
+        RESTPostAPIChatInputApplicationCommandsJSONBody,
+        RESTPostAPIContextMenuApplicationCommandsJSONBody,
+        RESTPostAPIPrimaryEntryPointApplicationCommandJSONBody,
 } from "discord-api-types/v10";
 
 import type { CommandInteraction } from "../utils/CommandInteractionOptions.js";
 import type {
-	UserContextMenuInteraction,
-	MessageContextMenuInteraction,
+        UserContextMenuInteraction,
+        MessageContextMenuInteraction,
+        AppCommandInteraction,
 } from "../utils/ContextMenuInteraction.js";
 import type {
         MiniInteractionComponent,
@@ -17,6 +19,7 @@ import type { CommandBuilder } from "../commands/CommandBuilder.js";
 import type {
         MessageCommandBuilder,
         UserCommandBuilder,
+        AppCommandBuilder,
 } from "../commands/ContextMenuCommandBuilder.js";
 
 /** Handler signature for slash command executions within MiniInteraction. */
@@ -31,23 +34,31 @@ export type UserCommandHandler = (
 
 /** Handler signature for message context menu command executions within MiniInteraction. */
 export type MessageCommandHandler = (
-	interaction: MessageContextMenuInteraction,
+        interaction: MessageContextMenuInteraction,
+) => Promise<APIInteractionResponse | void> | APIInteractionResponse | void;
+
+/** Handler signature for primary entry point command executions within MiniInteraction. */
+export type AppCommandHandler = (
+        interaction: AppCommandInteraction,
 ) => Promise<APIInteractionResponse | void> | APIInteractionResponse | void;
 
 /** Union of all command handler types. */
 export type CommandHandler =
-	| SlashCommandHandler
-	| UserCommandHandler
-	| MessageCommandHandler;
+        | SlashCommandHandler
+        | UserCommandHandler
+        | MessageCommandHandler
+        | AppCommandHandler;
 
 /** Structure representing a slash command definition and its runtime handler. */
 export type MiniInteractionCommand = {
         data:
                 | RESTPostAPIChatInputApplicationCommandsJSONBody
                 | RESTPostAPIContextMenuApplicationCommandsJSONBody
+                | RESTPostAPIPrimaryEntryPointApplicationCommandJSONBody
                 | CommandBuilder
                 | UserCommandBuilder
-                | MessageCommandBuilder;
+                | MessageCommandBuilder
+                | AppCommandBuilder;
         handler: CommandHandler;
         /**
          * Optional array of component handlers related to this command.

--- a/src/utils/ContextMenuInteraction.ts
+++ b/src/utils/ContextMenuInteraction.ts
@@ -1,23 +1,24 @@
 import {
 	InteractionResponseType,
 	type APIInteractionResponse,
-	type APIInteractionResponseCallbackData,
-	type APIInteractionResponseChannelMessageWithSource,
-	type APIInteractionResponseDeferredChannelMessageWithSource,
-	type APIInteractionResponseUpdateMessage,
-	type APIMessage,
-	type APIMessageApplicationCommandInteraction,
-	type APIModalInteractionResponse,
-	type APIModalInteractionResponseCallbackData,
-	type APIUser,
-	type APIUserApplicationCommandInteraction,
+        type APIInteractionResponseCallbackData,
+        type APIInteractionResponseChannelMessageWithSource,
+        type APIInteractionResponseDeferredChannelMessageWithSource,
+        type APIInteractionResponseUpdateMessage,
+        type APIMessage,
+        type APIMessageApplicationCommandInteraction,
+        type APIModalInteractionResponse,
+        type APIModalInteractionResponseCallbackData,
+        type APIPrimaryEntryPointCommandInteraction,
+        type APIUser,
+        type APIUserApplicationCommandInteraction,
 } from "discord-api-types/v10";
 
 import {
 	DeferReplyOptions,
-	InteractionMessageData,
-	normaliseInteractionMessageData,
-	normaliseMessageFlags,
+        InteractionMessageData,
+        normaliseInteractionMessageData,
+        normaliseMessageFlags,
 } from "./interactionMessageHelpers.js";
 
 /**
@@ -58,11 +59,18 @@ export type UserContextMenuInteraction =
  * Message context menu interaction with helper methods.
  */
 export type MessageContextMenuInteraction =
-	APIMessageApplicationCommandInteraction &
-		ContextMenuInteractionHelpers & {
-			/** Resolved message targeted by this message context menu command. */
-			targetMessage?: APIMessage;
-		};
+        APIMessageApplicationCommandInteraction &
+                ContextMenuInteractionHelpers & {
+                        /** Resolved message targeted by this message context menu command. */
+                        targetMessage?: APIMessage;
+                };
+
+/**
+ * Primary entry point interaction with helper methods.
+ */
+export type AppCommandInteraction =
+        APIPrimaryEntryPointCommandInteraction &
+                ContextMenuInteractionHelpers;
 
 function createContextMenuInteractionHelpers(): ContextMenuInteractionHelpers {
 	let capturedResponse: APIInteractionResponse | null = null;
@@ -189,11 +197,23 @@ export function createUserContextMenuInteraction(
  * @returns A helper-augmented interaction object.
  */
 export function createMessageContextMenuInteraction(
-	interaction: APIMessageApplicationCommandInteraction,
+        interaction: APIMessageApplicationCommandInteraction,
 ): MessageContextMenuInteraction {
-	return Object.assign(interaction, createContextMenuInteractionHelpers(), {
-		targetMessage: resolveTargetMessage(interaction),
-	});
+        return Object.assign(interaction, createContextMenuInteractionHelpers(), {
+                targetMessage: resolveTargetMessage(interaction),
+        });
+}
+
+/**
+ * Wraps a raw primary entry point interaction with helper methods.
+ *
+ * @param interaction - The raw primary entry point interaction payload from Discord.
+ * @returns A helper-augmented interaction object.
+ */
+export function createAppCommandInteraction(
+        interaction: APIPrimaryEntryPointCommandInteraction,
+): AppCommandInteraction {
+        return Object.assign(interaction, createContextMenuInteractionHelpers());
 }
 
 function resolveTargetMessage(


### PR DESCRIPTION
## Summary
- add an App command builder and handler type to represent Discord primary entry point commands
- extend interaction helpers and MiniInteraction command handling to process primary entry point interactions
- export new command types and ensure registration utilities accept the additional command payload

## Testing
- npm run typecheck

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69274829bd508329b99cf2beede2d9e7)